### PR TITLE
Fix compile error when use CPU_ONLY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ endif
 # All of the directories containing code.
 SRC_DIRS := $(shell find * -type d -exec bash -c "find {} -maxdepth 1 \
 	\( -name '*.cpp' -o -name '*.proto' \) | grep -q ." \; -print)
-
 # The target shared library name
 LIBRARY_NAME := $(PROJECT)
 LIB_BUILD_DIR := $(BUILD_DIR)/lib

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ In this demo, captcha images can contain digit sequence with different length(mo
 ![captcha image with 4 digits](/docs/images/captcha/99938-4518.png)
 ![captcha image with 5 digits](/docs/images/captcha/99937-82028.png)
 
+The original WarpCTC by Baidu Research supports multi-thread processing when using CPU. However it is not supported by this repo. So GPU is necessary for the following experiment, otherwise the running time will be unbearably long. Or you can reduce the dataset size to save time.
+
 To run the demo, first, make sure you are in `$CAFFE_ROOT` directory. Then, run the scripts to generate data using python `captcha` library and hdf5 files for trainning and testing.
 
 ```

--- a/include/caffe/3rdparty/ctc.h
+++ b/include/caffe/3rdparty/ctc.h
@@ -101,8 +101,29 @@ ctcStatus_t compute_ctc_loss(const float* const activations,
                              float *costs,
                              void *workspace,
                              ctcOptions options);
+ctcStatus_t compute_ctc_loss_cpu(const float* const activations,
+                             float* gradients,
+                             const int* const flat_labels,
+                             const int* const label_lengths,
+                             const int* const input_lengths,
+                             int alphabet_size,
+                             int minibatch,
+                             float *costs,
+                             void *workspace,
+                             ctcOptions options);
 
-
+#ifndef CPU_ONLY
+ctcStatus_t compute_ctc_loss_gpu(const float* const activations,
+                             float* gradients,
+                             const int* const flat_labels,
+                             const int* const label_lengths,
+                             const int* const input_lengths,
+                             int alphabet_size,
+                             int minibatch,
+                             float *costs,
+                             void *workspace,
+                             ctcOptions options);
+#endif
 /** For a given set of labels and minibatch size return the required workspace
  *  size.  This will need to be allocated in the same memory space as your
  *  probabilities.

--- a/include/caffe/3rdparty/detail/hostdevice.cuh
+++ b/include/caffe/3rdparty/detail/hostdevice.cuh
@@ -1,9 +1,9 @@
 #pragma once
-
+/*
 #ifndef __CUDACC__
 #define __CUDACC__
 #endif
-
+*/
 #ifdef __CUDACC__
     #define HOSTDEVICE __host__ __device__
 #else

--- a/include/caffe/layers/continuation_indicator_layer.hpp
+++ b/include/caffe/layers/continuation_indicator_layer.hpp
@@ -28,7 +28,7 @@ namespace caffe {
                                   const vector<Blob<Dtype>*>& bottom) {}
         virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
                                   const vector<bool>& propagate_down,
-                                  const vector<Blob<Dtype>*>& bottom) {}
+                                  const vector<Blob<Dtype>*>& bottom);
         int mini_batch_;
         int time_step_;
     };

--- a/src/caffe/3rdparty/ctc_entrypoint.cpp
+++ b/src/caffe/3rdparty/ctc_entrypoint.cpp
@@ -1,0 +1,175 @@
+#include <cstddef>
+#include <iostream>
+#include <algorithm>
+
+#include "caffe/3rdparty/ctc.h"
+
+#include "caffe/3rdparty/detail/cpu_ctc.cuh"
+
+
+extern "C" {
+
+int get_warpctc_version() {
+    return 2;
+}
+
+const char* ctcGetStatusString(ctcStatus_t status) {
+    switch (status) {
+    case CTC_STATUS_SUCCESS:
+        return "no error";
+    case CTC_STATUS_MEMOPS_FAILED:
+        return "cuda memcpy or memset failed";
+    case CTC_STATUS_INVALID_VALUE:
+        return "invalid value";
+    case CTC_STATUS_EXECUTION_FAILED:
+        return "execution failed";
+
+    case CTC_STATUS_UNKNOWN_ERROR:
+    default:
+        return "unknown error";
+
+    }
+
+}
+
+ctcStatus_t compute_ctc_loss_cpu(const float* const activations,
+                                 float* gradients,
+                                 const int* const flat_labels,
+                                 const int* const label_lengths,
+                                 const int* const input_lengths,
+                                 int alphabet_size,
+                                 int minibatch,
+                                 float* costs,
+                                 void* workspace,
+                                 ctcOptions options) {
+    CpuCTC<float> ctc(alphabet_size, minibatch, workspace,
+                      options.num_threads, options.blank_label);
+
+    if (gradients != NULL)
+      return ctc.cost_and_grad(activations, gradients,
+                               costs,
+                               flat_labels, label_lengths,
+                               input_lengths);
+    else
+      return ctc.score_forward(activations, costs, flat_labels,
+                               label_lengths, input_lengths);
+}
+
+ctcStatus_t compute_ctc_loss(const float* const activations,
+                             float* gradients,
+                             const int* const flat_labels,
+                             const int* const label_lengths,
+                             const int* const input_lengths,
+                             int alphabet_size,
+                             int minibatch,
+                             float *costs,
+                             void *workspace,
+                             ctcOptions options) {
+
+    if (activations == nullptr ||
+        flat_labels == nullptr ||
+        label_lengths == nullptr ||
+        input_lengths == nullptr ||
+        costs == nullptr ||
+        workspace == nullptr ||
+        alphabet_size <= 0 ||
+        minibatch <= 0)
+        return CTC_STATUS_INVALID_VALUE;
+
+    if(options.loc == CTC_CPU) {
+        return compute_ctc_loss_cpu(activations, gradients, flat_labels, label_lengths, input_lengths,
+                                    alphabet_size, minibatch, costs, workspace, options);
+    } else if(options.loc == CTC_GPU) {
+#ifndef CPU_ONLY
+        return compute_ctc_loss_gpu(activations, gradients, flat_labels, label_lengths, input_lengths,
+                                    alphabet_size, minibatch, costs, workspace, options);
+#endif
+    } else {
+        return CTC_STATUS_INVALID_VALUE;
+    }
+}
+
+
+ctcStatus_t get_workspace_size(const int* const label_lengths,
+                               const int* const input_lengths,
+                               int alphabet_size, int minibatch,
+                               ctcOptions options,
+                               size_t* size_bytes)
+{
+    if (label_lengths == nullptr ||
+        input_lengths == nullptr ||
+        size_bytes == nullptr ||
+        alphabet_size <= 0 ||
+        minibatch <= 0)
+        return CTC_STATUS_INVALID_VALUE;
+
+    // This is the max of all S and T for all examples in the minibatch.
+    int maxL = *std::max_element(label_lengths, label_lengths + minibatch);
+    int maxT = *std::max_element(input_lengths, input_lengths + minibatch);
+
+    const int S = 2 * maxL + 1;
+
+    *size_bytes = 0;
+
+    if (options.loc == CTC_GPU) {
+        // GPU storage
+        //nll_forward, nll_backward
+        *size_bytes += 2 * sizeof(float) * minibatch;
+
+        //repeats
+        *size_bytes += sizeof(int) * minibatch;
+
+        //label offsets
+        *size_bytes += sizeof(int) * minibatch;
+
+        //utt_length
+        *size_bytes += sizeof(int) * minibatch;
+
+        //label lengths
+        *size_bytes += sizeof(int) * minibatch;
+
+        //labels without blanks - overallocate for now
+        *size_bytes += sizeof(int) * maxL * minibatch;
+
+        //labels with blanks
+        *size_bytes += sizeof(int) * S * minibatch;
+
+        //alphas
+        *size_bytes += sizeof(float) * S * maxT * minibatch;
+
+        //denoms
+        *size_bytes += sizeof(float) * maxT * minibatch;
+
+        //probs (since we will pass in activations)
+        *size_bytes += sizeof(float) * alphabet_size * maxT * minibatch;
+
+    } else {
+        //cpu can eventually replace all minibatch with
+        //max number of concurrent threads if memory is
+        //really tight
+
+        //per minibatch memory
+        size_t per_minibatch_bytes = 0;
+
+        //output
+        per_minibatch_bytes += sizeof(float) * alphabet_size ;
+
+        //alphas
+        per_minibatch_bytes += sizeof(float) * S * maxT;
+
+        //betas
+        per_minibatch_bytes += sizeof(float) * S;
+
+        //labels w/blanks, e_inc, s_inc
+        per_minibatch_bytes += 3 * sizeof(int) * S;
+
+        *size_bytes = per_minibatch_bytes * minibatch;
+
+        //probs
+        *size_bytes += sizeof(float) * alphabet_size * maxT * minibatch;
+    }
+
+    return CTC_STATUS_SUCCESS;
+}
+
+}

--- a/src/caffe/3rdparty/ctc_entrypoint.cu
+++ b/src/caffe/3rdparty/ctc_entrypoint.cu
@@ -3,7 +3,7 @@
 #include <algorithm>
 
 #include "caffe/3rdparty/ctc.h"
-#include "caffe/3rdparty/detail/cpu_ctc.h"
+#include "caffe/3rdparty/detail/cpu_ctc.cuh"
 #ifdef __CUDACC__
 #include "caffe/3rdparty/detail/gpu_ctc.cuh"
 #endif
@@ -36,4 +36,5 @@ ctcStatus_t compute_ctc_loss_gpu(const float* const activations,
         std::cerr << "GPU execution requested, but not compiled with GPU support" << std::endl;
         return CTC_STATUS_EXECUTION_FAILED;
 #endif
+}
 }

--- a/src/caffe/3rdparty/ctc_entrypoint.cu
+++ b/src/caffe/3rdparty/ctc_entrypoint.cu
@@ -3,73 +3,24 @@
 #include <algorithm>
 
 #include "caffe/3rdparty/ctc.h"
-
-#include "caffe/3rdparty/detail/cpu_ctc.cuh"
+#include "caffe/3rdparty/detail/cpu_ctc.h"
 #ifdef __CUDACC__
-    #include "caffe/3rdparty/detail/gpu_ctc.cuh"
+#include "caffe/3rdparty/detail/gpu_ctc.cuh"
 #endif
 
 
 extern "C" {
 
-int get_warpctc_version() {
-    return 2;
-}
-
-const char* ctcGetStatusString(ctcStatus_t status) {
-    switch (status) {
-    case CTC_STATUS_SUCCESS:
-        return "no error";
-    case CTC_STATUS_MEMOPS_FAILED:
-        return "cuda memcpy or memset failed";
-    case CTC_STATUS_INVALID_VALUE:
-        return "invalid value";
-    case CTC_STATUS_EXECUTION_FAILED:
-        return "execution failed";
-
-    case CTC_STATUS_UNKNOWN_ERROR:
-    default:
-        return "unknown error";
-
-    }
-
-}
-
-
-ctcStatus_t compute_ctc_loss(const float* const activations,
-                             float* gradients,
-                             const int* const flat_labels,
-                             const int* const label_lengths,
-                             const int* const input_lengths,
-                             int alphabet_size,
-                             int minibatch,
-                             float *costs,
-                             void *workspace,
-                             ctcOptions options) {
-
-    if (activations == nullptr ||
-        flat_labels == nullptr ||
-        label_lengths == nullptr ||
-        input_lengths == nullptr ||
-        costs == nullptr ||
-        workspace == nullptr ||
-        alphabet_size <= 0 ||
-        minibatch <= 0)
-        return CTC_STATUS_INVALID_VALUE;
-
-    if (options.loc == CTC_CPU) {
-        CpuCTC<float> ctc(alphabet_size, minibatch, workspace, options.num_threads,
-                          options.blank_label);
-
-        if (gradients != NULL)
-            return ctc.cost_and_grad(activations, gradients,
-                                     costs,
-                                     flat_labels, label_lengths,
-                                     input_lengths);
-        else
-            return ctc.score_forward(activations, costs, flat_labels,
-                                     label_lengths, input_lengths);
-    } else if (options.loc == CTC_GPU) {
+ctcStatus_t compute_ctc_loss_gpu(const float* const activations,
+                                 float* gradients,
+                                 const int* const flat_labels,
+                                 const int* const label_lengths,
+                                 const int* const input_lengths,
+                                 int alphabet_size,
+                                 int minibatch,
+                                 float *costs,
+                                 void *workspace,
+                                 ctcOptions options) {
 #ifdef __CUDACC__
         GpuCTC<float> ctc(alphabet_size, minibatch, workspace, options.stream,
                           options.blank_label);
@@ -85,92 +36,4 @@ ctcStatus_t compute_ctc_loss(const float* const activations,
         std::cerr << "GPU execution requested, but not compiled with GPU support" << std::endl;
         return CTC_STATUS_EXECUTION_FAILED;
 #endif
-    } else {
-        return CTC_STATUS_INVALID_VALUE;
-    }
-}
-
-
-ctcStatus_t get_workspace_size(const int* const label_lengths,
-                               const int* const input_lengths,
-                               int alphabet_size, int minibatch,
-                               ctcOptions options,
-                               size_t* size_bytes)
-{
-    if (label_lengths == nullptr ||
-        input_lengths == nullptr ||
-        size_bytes == nullptr ||
-        alphabet_size <= 0 ||
-        minibatch <= 0)
-        return CTC_STATUS_INVALID_VALUE;
-
-    // This is the max of all S and T for all examples in the minibatch.
-    int maxL = *std::max_element(label_lengths, label_lengths + minibatch);
-    int maxT = *std::max_element(input_lengths, input_lengths + minibatch);
-
-    const int S = 2 * maxL + 1;
-
-    *size_bytes = 0;
-
-    if (options.loc == CTC_GPU) {
-        // GPU storage
-        //nll_forward, nll_backward
-        *size_bytes += 2 * sizeof(float) * minibatch;
-
-        //repeats
-        *size_bytes += sizeof(int) * minibatch;
-
-        //label offsets
-        *size_bytes += sizeof(int) * minibatch;
-
-        //utt_length
-        *size_bytes += sizeof(int) * minibatch;
-
-        //label lengths
-        *size_bytes += sizeof(int) * minibatch;
-
-        //labels without blanks - overallocate for now
-        *size_bytes += sizeof(int) * maxL * minibatch;
-
-        //labels with blanks
-        *size_bytes += sizeof(int) * S * minibatch;
-
-        //alphas
-        *size_bytes += sizeof(float) * S * maxT * minibatch;
-
-        //denoms
-        *size_bytes += sizeof(float) * maxT * minibatch;
-
-        //probs (since we will pass in activations)
-        *size_bytes += sizeof(float) * alphabet_size * maxT * minibatch;
-
-    } else {
-        //cpu can eventually replace all minibatch with
-        //max number of concurrent threads if memory is
-        //really tight
-
-        //per minibatch memory
-        size_t per_minibatch_bytes = 0;
-
-        //output
-        per_minibatch_bytes += sizeof(float) * alphabet_size ;
-
-        //alphas
-        per_minibatch_bytes += sizeof(float) * S * maxT;
-
-        //betas
-        per_minibatch_bytes += sizeof(float) * S;
-
-        //labels w/blanks, e_inc, s_inc
-        per_minibatch_bytes += 3 * sizeof(int) * S;
-
-        *size_bytes = per_minibatch_bytes * minibatch;
-
-        //probs
-        *size_bytes += sizeof(float) * alphabet_size * maxT * minibatch;
-    }
-
-    return CTC_STATUS_SUCCESS;
-}
-
 }

--- a/src/caffe/3rdparty/dummy.cpp
+++ b/src/caffe/3rdparty/dummy.cpp
@@ -1,2 +1,0 @@
-// do nothing
-// otherwise, makefile cannot find the `3rdparty` directory

--- a/src/caffe/layers/continuation_indicator_layer.cu
+++ b/src/caffe/layers/continuation_indicator_layer.cu
@@ -11,5 +11,10 @@ namespace caffe {
         caffe_gpu_set(mini_batch_, Dtype(0), top_data);
         caffe_gpu_set(mini_batch_*(time_step_ - 1), Dtype(1), top_data + mini_batch_);
     }
+    template <typename Dtype>
+    void ContinuationIndicatorLayer::Backward_gpu(const vector<Blob<Dtype>*>& top,
+            const vector<bool>& propagate_down,
+            const vector<Blob<Dtype>*>& bottom)
+    {}
 INSTANTIATE_LAYER_GPU_FUNCS(ContinuationIndicatorLayer);
 }

--- a/src/caffe/layers/continuation_indicator_layer.cu
+++ b/src/caffe/layers/continuation_indicator_layer.cu
@@ -12,7 +12,7 @@ namespace caffe {
         caffe_gpu_set(mini_batch_*(time_step_ - 1), Dtype(1), top_data + mini_batch_);
     }
     template <typename Dtype>
-    void ContinuationIndicatorLayer::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    void ContinuationIndicatorLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
             const vector<bool>& propagate_down,
             const vector<Blob<Dtype>*>& bottom)
     {}


### PR DESCRIPTION
Fix compile error when use CPU_ONLY.
- Split CPU and GPU code by adding `ctc_entrypoint.cu`
- remove unnessary `dummy.cpp`
- tested in GPU mode and CPU mode